### PR TITLE
Fix indentation and other violations of PEP8

### DIFF
--- a/motivatix/__init__.py
+++ b/motivatix/__init__.py
@@ -5,13 +5,14 @@ from config import config
 db = SQLAlchemy()
 app = None
 
-def create_app(config_name):
-	global app
-	app = Flask(__name__)
-	app.config.from_object(config[config_name])
-	with app.app_context():
-		db.init_app(app)
 
-	from models import Person, Achievement
-	from views import *
-	return app
+def create_app(config_name):
+    global app
+    app = Flask(__name__)
+    app.config.from_object(config[config_name])
+    with app.app_context():
+        db.init_app(app)
+
+    from models import Person, Achievement
+    from views import *
+    return app

--- a/motivatix/config.py
+++ b/motivatix/config.py
@@ -1,13 +1,15 @@
 class DevelopmentConfig():
-	SQLALCHEMY_DATABASE_URI = 'sqlite:///motivatix.db'
-	DEBUG = True
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///motivatix.db'
+    DEBUG = True
+
 
 class TestingConfig():
-	SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+
 
 config = {
-	'development': DevelopmentConfig,
-	'testing': TestingConfig,
+    'development': DevelopmentConfig,
+    'testing': TestingConfig,
 
-	'default': DevelopmentConfig
+    'default': DevelopmentConfig
 }

--- a/motivatix/models.py
+++ b/motivatix/models.py
@@ -1,18 +1,22 @@
 from . import db
 
-class Person(db.Model):
-	id = db.Column(db.Integer, primary_key=True)
-	name = db.Column(db.String, nullable=False)
-	achievements = db.relationship('Achievement', backref='person', lazy='dynamic')
 
-	def __repr__(self):
-		return "<Person(name='%s')>" % (self.name)
+class Person(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String, nullable=False)
+    achievements = db.relationship('Achievement', backref='person',
+                                   lazy='dynamic')
+
+    def __repr__(self):
+        return "<Person(name='%s')>" % (self.name)
+
 
 class Achievement(db.Model):
-	id = db.Column(db.Integer, primary_key=True)
-	description = db.Column(db.String, nullable=False)
-	age = db.Column(db.Integer)
-	person_id = db.Column(db.Integer, db.ForeignKey('person.id'))
+    id = db.Column(db.Integer, primary_key=True)
+    description = db.Column(db.String, nullable=False)
+    age = db.Column(db.Integer)
+    person_id = db.Column(db.Integer, db.ForeignKey('person.id'))
 
-	def __repr__(self):
-		return "<Achievement(name='%s', age='%s')>" % (self.description, self.age)
+    def __repr__(self):
+        return "<Achievement(name='%s', age='%s')>" % (self.description,
+                                                       self.age)

--- a/motivatix/views.py
+++ b/motivatix/views.py
@@ -4,21 +4,25 @@ from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 from . import app
 from models import Person, Achievement
 
+
 @app.route('/achievements/<name>/')
 def get_achievements_by_person(name):
-	name = name.replace('_', ' ')
-	try:
-		person = Person.query.filter_by(name=name).one()
-	except MultipleResultsFound:
-		abort(500) # Internal Server Error
-	except NoResultFound:
-		abort(404) # Not Found
-	response = [{'description': a.description, 'age': a.age} for a in person.achievements.all()]
-	return jsonify(achievements = response)
+    name = name.replace('_', ' ')
+    try:
+        person = Person.query.filter_by(name=name).one()
+    except MultipleResultsFound:
+        abort(500)  # Internal Server Error
+    except NoResultFound:
+        abort(404)  # Not Found
+    response = [{'description': a.description, 'age': a.age}
+                for a in person.achievements.all()]
+    return jsonify(achievements=response)
+
 
 @app.route('/achievements/<int:age>/')
 def get_achievements_by_age(age):
-	achievements = Achievement.query.filter_by(age=age).all()
+    achievements = Achievement.query.filter_by(age=age).all()
 
-	response = [{'person': a.person.name, 'description': a.description} for a in achievements]
-	return jsonify(achievements = response)
+    response = [{'person': a.person.name, 'description': a.description}
+                for a in achievements]
+    return jsonify(achievements=response)

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -5,41 +5,40 @@ from flask.ext.testing import TestCase
 from motivatix import create_app, db
 from motivatix.models import Person, Achievement
 
+
 class BaseTestCase(TestCase):
-	def create_app(self):
-		self.app = create_app('testing')
-		self.db = db
+    def create_app(self):
+        self.app = create_app('testing')
+        self.db = db
 
-		return self.app
+        return self.app
 
-	def setUp(self):
-		self.db.create_all()
-		self.populate_database()
+    def setUp(self):
+        self.db.create_all()
+        self.populate_database()
 
-	def tearDown(self):
-		self.db.session.remove()
-		self.db.drop_all()
+    def tearDown(self):
+        self.db.session.remove()
+        self.db.drop_all()
 
-	def populate_database(self):
-		larry_page = Person(name='Larry Page')
-		self.db.session.add(larry_page)
-		lp1 = Achievement(description='Started thinking about starting company', age=12)
-		lp2 = Achievement(description='Founded Google', age=25)
-		lp3 = Achievement(description='Announced Google Glass project', age=39)
-		self.db.session.add(lp1)
-		self.db.session.add(lp2)
-		self.db.session.add(lp3)
-		larry_page.achievements.append(lp1)
-		larry_page.achievements.append(lp2)
-		larry_page.achievements.append(lp3)
+    def populate_database(self):
+        larry = Person(name='Larry Page')
+        self.db.session.add(larry)
+        achievementsLarry = [('Started thinking about starting company', 12),
+                             ('Founded Google', 25),
+                             ('Announced Google Glass project', 39)]
+        for description, age in achievementsLarry:
+            a = Achievement(description=description, age=age)
+            self.db.session.add(a)
+            larry.achievements.append(a)
 
-		steve_jobs = Person(name='Steve Jobs')
-		self.db.session.add(steve_jobs)
-		sj1 = Achievement(description='Founded Apple Computer Company with Wozniak', age=21)
-		sj2 = Achievement(description='Stanford speech', age=50)
-		self.db.session.add(sj1)
-		self.db.session.add(sj2)
-		steve_jobs.achievements.append(sj1)
-		steve_jobs.achievements.append(sj2)
+        steve = Person(name='Steve Jobs')
+        self.db.session.add(steve)
+        achievementsSteve = [('Founded Apple Computer Company with Wozniak', 21),
+                             ('Stanford speech', 50)]
+        for description, age in achievementsSteve:
+            a = Achievement(description=description, age=age)
+            self.db.session.add(a)
+            steve.achievements.append(a)
 
-		self.db.session.commit()
+        self.db.session.commit()

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -34,7 +34,8 @@ class BaseTestCase(TestCase):
 
         steve = Person(name='Steve Jobs')
         self.db.session.add(steve)
-        achievementsSteve = [('Founded Apple Computer Company with Wozniak', 21),
+        achievementsSteve = [('Founded Apple Computer '
+                              'Company with Wozniak', 21),
                              ('Stanford speech', 50)]
         for description, age in achievementsSteve:
             a = Achievement(description=description, age=age)

--- a/test/test_achievements_by_person.py
+++ b/test/test_achievements_by_person.py
@@ -1,20 +1,16 @@
 from . import BaseTestCase
 
-class TestAchievementsByPerson(BaseTestCase):
-	def test_get_achievements_by_person(self):
-		expected = dict(achievements = [
-							{
-								'age': 21, 
-								'description': 'Founded Apple Computer Company with Wozniak'
-							}, 
-							{
-								'age': 50, 
-								'description': 'Stanford speech'
-							}])
-		response = self.client.get('/achievements/Steve_Jobs/')
-		self.assertItemsEqual(response.json['achievements'], expected['achievements'])
-		self.assertTrue(response.status_code == 200)
 
-	def test_not_found(self):
-		response = self.client.get('/achievements/No_one/')
-		self.assertTrue(response.status_code == 404)
+class TestAchievementsByPerson(BaseTestCase):
+    def test_get_achievements_by_person(self):
+        expected = {'achievements': [{'age': 21,
+                                      'description': 'Founded Apple Computer Company with Wozniak'},
+                                     {'age': 50,
+                                      'description': 'Stanford speech'}]}
+        response = self.client.get('/achievements/Steve_Jobs/')
+        self.assertItemsEqual(response.json['achievements'], expected['achievements'])
+        self.assertTrue(response.status_code == 200)
+
+    def test_not_found(self):
+        response = self.client.get('/achievements/No_one/')
+        self.assertTrue(response.status_code == 404)

--- a/test/test_achievements_by_person.py
+++ b/test/test_achievements_by_person.py
@@ -4,11 +4,13 @@ from . import BaseTestCase
 class TestAchievementsByPerson(BaseTestCase):
     def test_get_achievements_by_person(self):
         expected = {'achievements': [{'age': 21,
-                                      'description': 'Founded Apple Computer Company with Wozniak'},
+                                      'description': 'Founded Apple Computer '
+                                                     'Company with Wozniak'},
                                      {'age': 50,
                                       'description': 'Stanford speech'}]}
         response = self.client.get('/achievements/Steve_Jobs/')
-        self.assertItemsEqual(response.json['achievements'], expected['achievements'])
+        self.assertItemsEqual(response.json['achievements'],
+                              expected['achievements'])
         self.assertTrue(response.status_code == 200)
 
     def test_not_found(self):


### PR DESCRIPTION
Changed indentation from tabs to 4 spaces and fixed other PEP8 requirements with two exceptions - max line length in test/__init__.py (line 37) and test/test_achievements_by_person.py (lines 7 and 11) because breaking those lines would IMHO reduce readability.

Fixes #1.
